### PR TITLE
leafo/scssphp to latest 0.6.6, rtl-css mods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "prefer-stable": true,
   "require": {
     "matthiasmullie/minify": "^1.3",
-    "leafo/scssphp": "^0.6.2",
+    "leafo/scssphp": "^0.6.6",
     "cssjanus/cssjanus": "^1.1",
     "jenssegers/blade": "dev-master#64e40c988583a790224d0c379be3dd074417b217",
     "justinrainbow/json-schema": "^2.0"

--- a/src/factories/SassFactory.php
+++ b/src/factories/SassFactory.php
@@ -17,6 +17,7 @@ class SassFactory
 
     private $compiler;
     private $main;
+    private $mainRtl;
     private $minifier;
     private $compiledCss;
 
@@ -42,15 +43,14 @@ class SassFactory
                 throw new MicroFrameworkException('main.rtl.scss not found');
             }
 
-            $this->main = file_get_contents(PathHelper::getResourcesPath(self::mainRtlScssPath));
-        } else {
-            // load main.scss
-            if (!file_exists(PathHelper::getResourcesPath(self::mainScssPath))) {
-                throw new MicroFrameworkException('main.scss not found');
-            }
-
-            $this->main = file_get_contents(PathHelper::getResourcesPath(self::mainScssPath));
+            $this->mainRtl = file_get_contents(PathHelper::getResourcesPath(self::mainRtlScssPath));
         }
+            // load main.scss
+        if (!file_exists(PathHelper::getResourcesPath(self::mainScssPath))) {
+            throw new MicroFrameworkException('main.scss not found');
+        }
+
+        $this->main = file_get_contents(PathHelper::getResourcesPath(self::mainScssPath));
     }
 
     /**
@@ -71,6 +71,8 @@ class SassFactory
 
         if ($this->rtl) {
             $compiledSass = $this->rightToLeft($compiledSass);
+            $rtlSass = $this->compiler->compile($this->mainRtl);
+            $compiledSass = $compiledSass . $rtlSass;
         }
 
         // minify the result


### PR DESCRIPTION
Leafo/scssphp requirement updated to 0.6.6
Rtl css compile: rtl css is compuled from reversed ltr css with janus and all rtl components sass files are compiled and queued to the previously generated rtl css.

This mod permit to write ltr css as before, automate the compilation of rtl css, leaving rtl fixes in separated sass files.